### PR TITLE
Remove Laravel and Adonis examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This repo is a collection of reference examples for common language-specific Pos
 ## Client libraries and Frameworks
 
 - [PHP](./php)
-  - [Laravel](./laravel)
 - [NodeJS](./nodejs)
-  - [AdonisJS](./adonisjs)
 - [TypeScript](./typescript)
 - [Deno](./deno)
 - [Java](./java)

--- a/adonisjs/README.md
+++ b/adonisjs/README.md
@@ -1,3 +1,0 @@
-# Materialize + Adonis Example
-
-[Building a real-time web application with Materialize and AdonisJS](https://devdojo.com/bobbyiliev/building-a-real-time-web-application-with-materialize-and-adonisjs)

--- a/laravel/README.md
+++ b/laravel/README.md
@@ -1,3 +1,0 @@
-# Materialize + Laravel Example
-
-[How to connect Laravel to Materialize and build a live dashboard?](https://devdojo.com/bobbyiliev/how-to-connect-laravel-to-materialize)


### PR DESCRIPTION
Removing the Laravel and Adonis examples as they were just references to external tutorials for the Materialize Binary. 