### PR TITLE
Rust: remove `sleep` from `subscribe.rs`

### DIFF
--- a/rust/src/subscribe.rs
+++ b/rust/src/subscribe.rs
@@ -1,5 +1,3 @@
-use std::{thread::sleep, time::Duration};
-
 use crate::connection::create_client;
 
 /// Run a subscribe over the PUBNUB materialized view
@@ -13,6 +11,5 @@ pub(crate) fn subscribe() {
         for row in results {
             println!("{:} - {:}", row.get::<usize, String>(2), row.get::<usize, String>(3));
         }
-        sleep(Duration::from_millis(200));
     }
 }


### PR DESCRIPTION
Reflecting [Materialize #21344](https://github.com/MaterializeInc/materialize/pull/21344).